### PR TITLE
Use GEMINI_API_KEY for GenAI clients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ pytest tests/ -v --tb=short
 
 ## Environment Variables
 ```bash
-GOOGLE_API_KEY=        # Required for Gemini API
+GEMINI_API_KEY=        # Required for Gemini API
 SACRED_APPROVAL_KEY=   # Required for approving Sacred Plans
 MCP_CACHE_TTL_SECONDS=300 # Optional: Cache duration for the MCP server
 ```

--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -37,7 +37,7 @@ vim .env
 
 You need to set these **required** variables:
 
-1. `GOOGLE_API_KEY` or `GEMINI_API_KEY` (or both - they can be the same value)
+1. `GEMINI_API_KEY`
 2. `SACRED_APPROVAL_KEY`
 
 ## Google AI API Key Setup
@@ -67,8 +67,6 @@ Go to: [https://aistudio.google.com/app/apikey](https://aistudio.google.com/app/
 Open your `.env` file and add:
 
 ```env
-# Use the same key for both variables
-GOOGLE_API_KEY=your-actual-api-key-here
 GEMINI_API_KEY=your-actual-api-key-here
 ```
 
@@ -94,7 +92,6 @@ Only use this if you need advanced Google Cloud features or have existing Google
 #### Step 3: Configure Environment
 
 ```env
-GOOGLE_API_KEY=your-google-cloud-api-key
 GEMINI_API_KEY=your-google-cloud-api-key
 
 # Optional: Google Cloud specific settings
@@ -178,7 +175,7 @@ CHROMADB_PERSIST_DIR=./custom_db_path
 source .env
 
 # Verify Google API key is set
-echo $GOOGLE_API_KEY
+echo $GEMINI_API_KEY
 
 # Verify Sacred key is set  
 echo $SACRED_APPROVAL_KEY
@@ -223,14 +220,14 @@ Expected response:
 
 **Solutions**:
 1. Verify `.env` file exists in the correct directory
-2. Check that variable names are correct (`GOOGLE_API_KEY` or `GEMINI_API_KEY`)
+2. Check that variable name is correct (`GEMINI_API_KEY`)
 3. Ensure no extra spaces around the `=` sign
 4. Verify the API key is valid (no extra characters, correct length)
 
 **Test your key**:
 ```bash
 # Should show your key (first few characters)
-head -c 20 <<< "$GOOGLE_API_KEY"
+head -c 20 <<< "$GEMINI_API_KEY"
 ```
 
 #### "Sacred approval key invalid" Error
@@ -356,7 +353,7 @@ For production deployments:
 1. **Use container secrets**
    ```dockerfile
    # In Docker
-   ENV GOOGLE_API_KEY_FILE=/run/secrets/google_api_key
+   ENV GEMINI_API_KEY_FILE=/run/secrets/gemini_api_key
    ENV SACRED_APPROVAL_KEY_FILE=/run/secrets/sacred_key
    ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -35,8 +35,7 @@ nano .env
 Required environment variables:
 ```bash
 # Google Cloud (for embeddings and LLM)
-GOOGLE_API_KEY=your-google-api-key
-GEMINI_API_KEY=your-gemini-api-key  # Same as GOOGLE_API_KEY
+GEMINI_API_KEY=your-gemini-api-key
 
 # Sacred Layer (v3.0)
 SACRED_APPROVAL_KEY=your-secret-approval-key
@@ -147,11 +146,11 @@ http://localhost:5556/analytics_dashboard_live.html
 **Google Cloud Authentication:**
 ```bash
 # Check API key is set
-echo $GOOGLE_API_KEY
+echo $GEMINI_API_KEY
 
 # Test API access
 curl -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $GOOGLE_API_KEY" \
+  -H "Authorization: Bearer $GEMINI_API_KEY" \
   https://generativelanguage.googleapis.com/v1beta/models
 ```
 

--- a/docs/SECURITY_GUIDELINES.md
+++ b/docs/SECURITY_GUIDELINES.md
@@ -25,7 +25,6 @@ Comprehensive security best practices for deploying and managing ContextKeeper v
 # Visit: https://aistudio.google.com/app/apikey
 
 # Store keys securely - never in code
-GOOGLE_API_KEY=your-secure-api-key-here
 GEMINI_API_KEY=your-secure-api-key-here
 ```
 
@@ -50,12 +49,12 @@ git add .env  # DANGEROUS - ensure .env is in .gitignore
 NEW_KEY="your-new-api-key"
 
 # 2. Test new key before deployment
-export GOOGLE_API_KEY_NEW=$NEW_KEY
+export GEMINI_API_KEY_NEW=$NEW_KEY
 python3 -c "import genai; genai.configure(api_key='$NEW_KEY'); print('New key works')"
 
 # 3. Update production environment (with rollback plan)
 cp .env .env.backup.$(date +%Y%m%d)
-sed -i "s/GOOGLE_API_KEY=.*/GOOGLE_API_KEY=$NEW_KEY/" .env
+sed -i "s/GEMINI_API_KEY=.*/GEMINI_API_KEY=$NEW_KEY/" .env
 
 # 4. Restart services
 systemctl restart contextkeeper
@@ -159,22 +158,22 @@ services:
     image: contextkeeper:v3
     secrets:
       - sacred_key
-      - google_api_key
+      - gemini_api_key
     environment:
       - SACRED_APPROVAL_KEY_FILE=/run/secrets/sacred_key
-      - GOOGLE_API_KEY_FILE=/run/secrets/google_api_key
+      - GEMINI_API_KEY_FILE=/run/secrets/gemini_api_key
 
 secrets:
   sacred_key:
     external: true
-  google_api_key:
+  gemini_api_key:
     external: true
 ```
 
 ```bash
 # Create Docker secrets
 echo "your-sacred-key" | docker secret create sacred_key -
-echo "your-api-key" | docker secret create google_api_key -
+echo "your-api-key" | docker secret create gemini_api_key -
 ```
 
 ### 3. Sacred Layer Validation
@@ -246,7 +245,7 @@ import os
 
 class Config:
     """Base configuration class."""
-    GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')
+    GEMINI_API_KEY = os.environ.get('GEMINI_API_KEY')
     SACRED_APPROVAL_KEY = os.environ.get('SACRED_APPROVAL_KEY')
     
 class DevelopmentConfig(Config):
@@ -304,15 +303,15 @@ class EnvironmentValidator:
     """Validate environment configuration for security compliance."""
     
     REQUIRED_VARS = [
-        'GOOGLE_API_KEY',
+        'GEMINI_API_KEY',
         'SACRED_APPROVAL_KEY'
     ]
     
     SECURITY_CHECKS = {
-        'GOOGLE_API_KEY': {
+        'GEMINI_API_KEY': {
             'min_length': 30,
             'pattern': r'^AIza[0-9A-Za-z_-]{35}$',  # Google API key format
-            'description': 'Google AI API key format'
+            'description': 'Gemini API key format'
         },
         'SACRED_APPROVAL_KEY': {
             'min_length': 32,
@@ -753,11 +752,11 @@ services:
     
     # Secrets management
     secrets:
-      - google_api_key
+      - gemini_api_key
       - sacred_approval_key
-    
+
     environment:
-      - GOOGLE_API_KEY_FILE=/run/secrets/google_api_key
+      - GEMINI_API_KEY_FILE=/run/secrets/gemini_api_key
       - SACRED_APPROVAL_KEY_FILE=/run/secrets/sacred_approval_key
     
     # Volume security
@@ -785,7 +784,7 @@ volumes:
     driver: local
 
 secrets:
-  google_api_key:
+  gemini_api_key:
     external: true
   sacred_approval_key:
     external: true
@@ -842,11 +841,11 @@ spec:
         
         # Environment from secrets
         env:
-        - name: GOOGLE_API_KEY
+        - name: GEMINI_API_KEY
           valueFrom:
             secretKeyRef:
               name: contextkeeper-secrets
-              key: google-api-key
+              key: gemini-api-key
         - name: SACRED_APPROVAL_KEY
           valueFrom:
             secretKeyRef:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -22,7 +22,7 @@ pip install -r requirements.txt
 # 4. Set up environment variables
 cp .env.template .env
 # Edit .env and add your keys:
-# GOOGLE_API_KEY=your-google-api-key
+# GEMINI_API_KEY=your-gemini-api-key
 # SACRED_APPROVAL_KEY=a-long-secret-key-you-create
 ```
 

--- a/rag_agent.py
+++ b/rag_agent.py
@@ -487,11 +487,11 @@ class ProjectKnowledgeAgent:
         try:
             self.embedder = genai.Client(
                 http_options=HttpOptions(api_version="v1beta"),
-                api_key=os.environ.get("GOOGLE_API_KEY")
+                api_key=os.environ.get("GEMINI_API_KEY")
             )
             # Initialize content generation client for LLM responses
             self.client = genai.Client(
-                api_key=os.environ.get("GOOGLE_API_KEY")
+                api_key=os.environ.get("GEMINI_API_KEY")
             )
             # Create embedding function for ChromaDB
             self.embedding_function = GoogleGenAIEmbeddingFunction(


### PR DESCRIPTION
## Summary
- Use `GEMINI_API_KEY` for all Google GenAI client configuration.
- Refresh installation, environment, security, and developer docs to reference the unified key.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sacred_layer_implementation')*

------
https://chatgpt.com/codex/tasks/task_e_6894170ea544832ea37ff9756d81897b