### PR TITLE
Require SACRED_APPROVAL_KEY for plan verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ pip install -r requirements.txt
 ```bash
 # Copy the template and edit the new .env file
 cp .env.template .env
-# Add your Google API key and create a secret approval key
+# Add your Google API key and define a SACRED_APPROVAL_KEY (required)
 ```
+
+The `SACRED_APPROVAL_KEY` environment variable must be set in your shell or `.env` file.
+Plan approval will fail if this key is missing.
 
 ### 3. Start ContextKeeper
 ```bash

--- a/contextkeeper_manager.sh
+++ b/contextkeeper_manager.sh
@@ -233,7 +233,13 @@ main() {
         exit 1
     fi
     print_success "Dependencies OK"
-    
+
+    # Ensure sacred approval key is set
+    if [ -z "$SACRED_APPROVAL_KEY" ]; then
+        print_error "SACRED_APPROVAL_KEY environment variable is required"
+        exit 1
+    fi
+
     # Check/start server
     if check_server; then
         print_success "Server is already running"

--- a/scripts/contextkeeper.sh
+++ b/scripts/contextkeeper.sh
@@ -24,6 +24,11 @@
 
 set -e
 
+if [ -z "$SACRED_APPROVAL_KEY" ]; then
+    echo "Error: SACRED_APPROVAL_KEY environment variable is required"
+    exit 1
+fi
+
 RAG_AGENT_URL="http://localhost:5556"
 
 function usage() {

--- a/setup.sh
+++ b/setup.sh
@@ -28,8 +28,14 @@ if [ ! -f ".env" ]; then
     echo "Please edit .env with your Google Cloud credentials:"
     echo "  1. Set GOOGLE_CLOUD_PROJECT to your project ID"
     echo "  2. Set GOOGLE_APPLICATION_CREDENTIALS to your service account JSON path"
+    echo "  3. Set SACRED_APPROVAL_KEY to your secret approval key (required)"
     echo ""
     read -p "Press Enter to continue after editing .env..."
+fi
+
+# Warn if SACRED_APPROVAL_KEY is missing
+if [ -z "$SACRED_APPROVAL_KEY" ] && ! grep -q "SACRED_APPROVAL_KEY" .env 2>/dev/null; then
+    echo "⚠️  SACRED_APPROVAL_KEY is not set. Define it in your environment or .env before approving plans."
 fi
 
 # Make CLI executable

--- a/src/sacred/sacred_layer_implementation.py
+++ b/src/sacred/sacred_layer_implementation.py
@@ -394,7 +394,9 @@ class SacredLayerManager:
         # - Custom business logic
         
         # For demo, check against environment variable
-        expected = os.environ.get('SACRED_APPROVAL_KEY', 'default-key')
+        expected = os.environ.get('SACRED_APPROVAL_KEY')
+        if not expected:
+            raise RuntimeError("SACRED_APPROVAL_KEY environment variable is required")
         return verification == expected
     def get_plan_status(self, plan_id: str) -> Optional[Dict[str, Any]]:
         """Get status and metadata for a plan"""


### PR DESCRIPTION
## Summary
- Ensure `SACRED_APPROVAL_KEY` is set in `_verify_secondary` and raise an error when it is missing.
- Document the required `SACRED_APPROVAL_KEY` in the README, setup script, and deployment utilities.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'project_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6894170dfe30832ea4409d12889c6686