### PR TITLE
Enforce explicit SACRED_APPROVAL_KEY configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ pip install -r requirements.txt
 ```bash
 # Copy the template and edit the new .env file
 cp .env.template .env
-# Add your Google API key and define a SACRED_APPROVAL_KEY (required)
+# Add your Google API key and define a SACRED_APPROVAL_KEY (required; no default)
 ```
 
-The `SACRED_APPROVAL_KEY` environment variable must be set in your shell or `.env` file.
-Plan approval will fail if this key is missing.
+The `SACRED_APPROVAL_KEY` environment variable must be set in your shell or `.env` file. There is no default value and
+ContextKeeper will raise an error if this key is missing.
 
 ### 3. Start ContextKeeper
 ```bash

--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -40,6 +40,8 @@ You need to set these **required** variables:
 1. `GEMINI_API_KEY`
 2. `SACRED_APPROVAL_KEY`
 
+> **Note:** There is no default value for `SACRED_APPROVAL_KEY`. ContextKeeper will raise an error if this key is not set.
+
 ## Google AI API Key Setup
 
 ### Option 1: Google AI Studio (Recommended)
@@ -131,6 +133,8 @@ Add to your `.env` file:
 SACRED_APPROVAL_KEY=your-64-character-hex-string-here
 ```
 
+This key is mandatory for plan approval; operations will fail if it is absent.
+
 **Example:**
 ```env
 SACRED_APPROVAL_KEY=a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456
@@ -146,7 +150,7 @@ Most users can skip this section. These settings have sensible defaults.
 # RAG Agent Service URL (default: http://localhost:5556)
 RAG_AGENT_URL=http://localhost:5556
 
-# Server Configuration (defaults usually work)  
+# Server Configuration (defaults usually work)
 CONTEXTKEEPER_HOST=127.0.0.1
 CONTEXTKEEPER_PORT=5556
 ```
@@ -177,7 +181,7 @@ source .env
 # Verify Google API key is set
 echo $GEMINI_API_KEY
 
-# Verify Sacred key is set  
+# Verify Sacred key is set
 echo $SACRED_APPROVAL_KEY
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -37,7 +37,7 @@ Required environment variables:
 # Google Cloud (for embeddings and LLM)
 GEMINI_API_KEY=your-gemini-api-key
 
-# Sacred Layer (v3.0)
+# Sacred Layer (v3.0) - required, no default
 SACRED_APPROVAL_KEY=your-secret-approval-key
 
 # Optional: Analytics and Performance
@@ -45,6 +45,8 @@ ANALYTICS_CACHE_DURATION=300  # Cache duration in seconds (default: 300)
 FLASK_ASYNC_MODE=True         # Enable async endpoints (default: True)
 DEBUG=0                       # Set to 1 for debug logging
 ```
+
+ContextKeeper will raise an error during plan approval if `SACRED_APPROVAL_KEY` is not set.
 
 ### 3. Verify Installation
 ```bash


### PR DESCRIPTION
## Summary
- error when `SACRED_APPROVAL_KEY` is missing instead of using a default
- document that `SACRED_APPROVAL_KEY` must be explicitly configured

## Testing
- `pre-commit run --files src/sacred/sacred_layer_implementation.py README.md docs/ENVIRONMENT_SETUP.md docs/INSTALLATION.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sacred_layer_implementation')*

------
https://chatgpt.com/codex/tasks/task_e_689424f98868832eb0fc1e0893a2ae5b