### PR TITLE
Replace plan modal timeout with API call

### DIFF
--- a/analytics_dashboard_live.html
+++ b/analytics_dashboard_live.html
@@ -784,15 +784,25 @@
             }
         }
 
-        function openViewPlanModal(planId) {
-            // In a real app, you would fetch plan content here
-            document.getElementById('viewPlanTitle').textContent = `Plan: ${planId}`;
-            document.getElementById('viewPlanContent').textContent = 'Loading plan content...';
-            document.getElementById('viewPlanModal').classList.remove('hidden');
-            // Mock fetching content
-            setTimeout(() => {
-                 document.getElementById('viewPlanContent').textContent = `Content for plan ${planId} would be displayed here. This requires a new endpoint to fetch plan content by ID.`;
-            }, 500);
+        async function openViewPlanModal(planId) {
+            const modal = document.getElementById('viewPlanModal');
+            const titleEl = document.getElementById('viewPlanTitle');
+            const contentEl = document.getElementById('viewPlanContent');
+
+            titleEl.textContent = `Plan: ${planId}`;
+            contentEl.innerHTML = '<p class="text-slate-300 animate-pulse">Loading plan content...</p>';
+            modal.classList.remove('hidden');
+
+            try {
+                const response = await fetch(`${API_BASE}/sacred/plans/${planId}`);
+                if (!response.ok) throw new Error(`Failed to load plan (${response.status})`);
+                const plan = await response.json();
+                titleEl.textContent = plan.title || `Plan: ${planId}`;
+                contentEl.textContent = plan.content || 'No content available.';
+            } catch (error) {
+                console.error('Error loading plan:', error);
+                contentEl.innerHTML = `<p class="text-red-400 text-center">Error loading plan: ${error.message}</p>`;
+            }
         }
         function closeViewPlanModal() { document.getElementById('viewPlanModal').classList.add('hidden'); }
 

--- a/rag_agent.py
+++ b/rag_agent.py
@@ -1441,6 +1441,30 @@ class RAGServer:
                 logger.error(f"Error listing sacred plans: {str(e)}")
                 return jsonify({'error': str(e)}), 500
 
+        @self.app.route('/sacred/plans/<plan_id>', methods=['GET'])
+        def get_sacred_plan(plan_id):
+            """Retrieve full sacred plan content"""
+            try:
+                sacred_manager = self.agent.sacred_integration.sacred_manager
+
+                if plan_id not in sacred_manager.plans_registry:
+                    return jsonify({'error': 'Plan not found'}), 404
+
+                plan = sacred_manager.plans_registry[plan_id]
+                return jsonify({
+                    'plan_id': plan.plan_id,
+                    'project_id': plan.project_id,
+                    'title': plan.title,
+                    'content': plan.content,
+                    'status': plan.status.value,
+                    'created_at': plan.created_at,
+                    'approved_at': plan.approved_at,
+                    'approved_by': plan.approved_by
+                })
+            except Exception as e:
+                logger.error(f"Error getting sacred plan: {str(e)}")
+                return jsonify({'error': str(e)}), 500
+
         @self.app.route('/sacred/plans/<plan_id>/approve', methods=['POST'])
         def approve_sacred_plan(plan_id):
             data = request.json

--- a/tests/sacred/test_plan_endpoint.py
+++ b/tests/sacred/test_plan_endpoint.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Tests for sacred plan retrieval endpoint"""
+
+from unittest.mock import Mock, patch
+from rag_agent import RAGServer
+from src.sacred.sacred_layer_implementation import SacredPlan, PlanStatus
+
+
+def test_get_sacred_plan_endpoint():
+    plan = SacredPlan(
+        plan_id="plan123",
+        project_id="proj1",
+        title="Test Plan",
+        content="Plan content",
+        status=PlanStatus.DRAFT,
+        created_at="2025-01-01T00:00:00",
+        approved_at=None,
+        approved_by=None,
+        verification_code=None
+    )
+
+    sacred_manager = Mock(plans_registry={"plan123": plan})
+    agent = Mock(
+        project_manager=Mock(),
+        sacred_integration=Mock(sacred_manager=sacred_manager)
+    )
+
+    with patch('rag_agent.add_sacred_drift_endpoint'):
+        server = RAGServer(agent)
+        client = server.app.test_client()
+        resp = client.get('/sacred/plans/plan123')
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['plan_id'] == 'plan123'
+    assert data['content'] == 'Plan content'


### PR DESCRIPTION
## Summary
- add `/sacred/plans/<plan_id>` endpoint to expose plan content
- fetch plan data in dashboard instead of simulating with `setTimeout`
- test sacred plan retrieval endpoint

## Testing
- `pytest tests/sacred/test_plan_endpoint.py`
- `pytest tests/sacred/test_sacred_layer.py -k test_create_plan_basic` *(fails: ModuleNotFoundError: No module named 'sacred_layer_implementation')*

------
https://chatgpt.com/codex/tasks/task_e_689424fd8db4832eacd86177866899f8