### PR TITLE
Add Flask utilities import to drift detection module

### DIFF
--- a/src/sacred/enhanced_drift_sacred.py
+++ b/src/sacred/enhanced_drift_sacred.py
@@ -39,6 +39,7 @@ from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
+from flask import request, jsonify
 import logging
 from datetime import datetime, timedelta
 


### PR DESCRIPTION
## Summary
- add `request` and `jsonify` imports from Flask to `enhanced_drift_sacred`

## Testing
- `PYTHONPATH=src/sacred pytest tests/sacred/test_sacred_layer.py::TestSacredLayerManager::test_initialization -q` *(fails: AttributeError: 'RecursiveCharacterTextSplitter' object has no attribute 'chunk_size')*

------
https://chatgpt.com/codex/tasks/task_e_6894363b13e4832ea99425864ab70f1b