### PR TITLE
refactor: explicitly export chat interface components

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -4,7 +4,7 @@ import React, { useState, useRef, useEffect } from 'react';
 // Matches glass morphism design with dark theme
 // WCAG AA compliant with keyboard navigation and screen reader support
 
-const ChatInterface = () => {
+export const ChatInterface = () => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [messages, setMessages] = useState([
     {
@@ -286,4 +286,3 @@ const ChatInterface = () => {
     </>
   );
 };
-export default ChatInterface;

--- a/src/components/ChatInterfaceDemo.jsx
+++ b/src/components/ChatInterfaceDemo.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ChatInterface from './ChatInterface';
+import { ChatInterface } from './ChatInterface';
 
 // Demo Component showing the chat interface in action
 export const ChatInterfaceDemo = () => {
@@ -33,4 +33,3 @@ export const ChatInterfaceDemo = () => {
   );
 };
 
-export default ChatInterfaceDemo;


### PR DESCRIPTION
## Summary
- refactor ChatInterface to use explicit export
- update ChatInterfaceDemo to import ChatInterface and remove default export

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sacred_layer_implementation')*

------
https://chatgpt.com/codex/tasks/task_e_6894363baa9c832e8128f5f377fac793