### PR TITLE
Add path normalization helper for test stability

### DIFF
--- a/src/core/path_utils.py
+++ b/src/core/path_utils.py
@@ -1,0 +1,18 @@
+"""Utility functions for filesystem path handling."""
+
+from __future__ import annotations
+
+import os
+
+
+def normalize_path(path_str: str) -> str:
+    """Return a normalized version of *path_str* using forward slashes.
+
+    This function collapses redundant separators and up-level references and
+    converts any Windows style backslashes to forward slashes so that paths are
+    handled consistently across platforms.
+    """
+    if path_str is None:
+        return ""
+    normalized = os.path.normpath(path_str)
+    return normalized.replace("\\", "/")

--- a/tests/test_v3_upgrade.py
+++ b/tests/test_v3_upgrade.py
@@ -1,10 +1,9 @@
 import pytest
 import asyncio
 from rag_agent import ProjectKnowledgeAgent, RAGServer
-from src.core.project_manager import ProjectManager
 import os
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+
 
 @pytest.fixture(scope="module")
 def event_loop():
@@ -13,8 +12,9 @@ def event_loop():
     yield loop
     loop.close()
 
+
 @pytest.fixture(scope="module")
-async def test_agent():
+def test_agent():
     config = {
         "db_path": "./test_rag_knowledge_db",
         "projects_config_dir": os.path.expanduser("~/.test_rag_projects"),
@@ -26,34 +26,43 @@ async def test_agent():
         "api_port": 5557,
         "ignore_directories": ["node_modules", ".git", "__pycache__"],
         "ignore_files": ["*.log"],
-        "sensitive_patterns": []
+        "sensitive_patterns": [],
     }
     # Clean up previous test runs
     if os.path.exists(config["db_path"]):
         import shutil
+
         shutil.rmtree(config["db_path"])
     if os.path.exists(config["projects_config_dir"]):
         import shutil
+
         shutil.rmtree(config["projects_config_dir"])
 
     agent = ProjectKnowledgeAgent(config)
 
     # Mock the embedding client
     agent.embedder = MagicMock()
-    agent.embedder.models.embed_content.return_value = MagicMock(embeddings=[MagicMock(values=[0.1] * 768)])
+    agent.embedder.models.embed_content.return_value = MagicMock(
+        embeddings=[MagicMock(values=[0.1] * 768)]
+    )
 
     # Create a test project
-    agent.project_manager.create_project("Test Project", "/tmp/test_project", ["/tmp/test_project"])
+    agent.project_manager.create_project(
+        "Test Project", "/tmp/test_project", ["/tmp/test_project"]
+    )
 
     yield agent
 
     # Clean up
     if os.path.exists(config["db_path"]):
         import shutil
+
         shutil.rmtree(config["db_path"])
     if os.path.exists(config["projects_config_dir"]):
         import shutil
+
         shutil.rmtree(config["projects_config_dir"])
+
 
 @pytest.fixture(scope="module")
 def client(test_agent):
@@ -61,27 +70,33 @@ def client(test_agent):
     with server.app.test_client() as client:
         yield client
 
+
 def test_git_activity_endpoint(client):
     # This is a basic test, as we don't have a git repo initialized
-    response = client.get('/projects/proj_1/git/activity')
-    assert response.status_code == 404 # No git repo initialized
+    response = client.get("/projects/proj_1/git/activity")
+    assert response.status_code == 404  # No git repo initialized
+
 
 def test_create_sacred_plan(client):
-    response = client.post('/sacred/plans', json={
-        "project_id": "proj_1",
-        "title": "Test Plan",
-        "content": "This is a test plan."
-    })
+    response = client.post(
+        "/sacred/plans",
+        json={
+            "project_id": "proj_1",
+            "title": "Test Plan",
+            "content": "This is a test plan.",
+        },
+    )
     assert response.status_code == 200
     data = response.get_json()
-    assert data['status'] == 'created'
-    assert 'plan_id' in data
-    assert 'verification_code' in data
+    assert data["status"] == "created"
+    assert "plan_id" in data
+    assert "verification_code" in data
+
 
 def test_analytics_summary_endpoint(client):
-    response = client.get('/analytics/summary')
+    response = client.get("/analytics/summary")
     assert response.status_code == 200
     data = response.get_json()
-    assert 'total_projects' in data
-    assert 'active_projects' in data
-    assert 'projects' in data
+    assert "total_projects" in data
+    assert "active_projects" in data
+    assert "projects" in data

--- a/tests/unit/test_path_filtering.py
+++ b/tests/unit/test_path_filtering.py
@@ -12,28 +12,30 @@ for nested structures. Validates the recently fixed path filtering issues.
 
 import pytest
 import os
-import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch
 import sys
 
+from src.core.path_utils import normalize_path
+
 # Add parent directory to path for imports
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.append(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 
 
 @pytest.mark.unit
 class TestPathFilteringLogic:
     """Test core path filtering logic and exclusion rules"""
-    
+
     @pytest.fixture
     def sample_directory_structure(self, temp_dir):
         """Create a sample directory structure for testing path filtering"""
         base_path = Path(temp_dir)
-        
+
         # Create various directories and files to test filtering
         directories_to_create = [
             "src/main",
-            "src/utils", 
+            "src/utils",
             "tests/unit",
             "tests/integration",
             "venv/lib/python3.9/site-packages/requests",
@@ -47,24 +49,23 @@ class TestPathFilteringLogic:
             "build/lib/mypackage",
             "dist/mypackage-1.0.0",
             ".tox/py39/lib",
-            "docs/build/html"
+            "docs/build/html",
         ]
-        
+
         for dir_path in directories_to_create:
             (base_path / dir_path).mkdir(parents=True, exist_ok=True)
-        
+
         # Create test files in various locations
         files_to_create = [
             # Should be included
             "src/main/app.py",
             "src/utils/helpers.py",
-            "tests/unit/test_app.py", 
+            "tests/unit/test_app.py",
             "tests/integration/test_api.py",
             "README.md",
             "setup.py",
             "requirements.txt",
             "docs/source/index.rst",
-            
             # Should be excluded
             "venv/lib/python3.9/site-packages/requests/__init__.py",
             "venv/lib/python3.9/site-packages/numpy/core.py",
@@ -77,41 +78,49 @@ class TestPathFilteringLogic:
             "build/lib/mypackage/__init__.py",
             "dist/mypackage-1.0.0/setup.py",
             ".tox/py39/lib/python/site-packages/test.py",
-            "docs/build/html/index.html"
+            "docs/build/html/index.html",
         ]
-        
+
         for file_path in files_to_create:
             file_full_path = base_path / file_path
             file_full_path.parent.mkdir(parents=True, exist_ok=True)
             file_full_path.write_text(f"# Content of {file_path}")
-        
+
         return base_path
-    
+
     def test_venv_exclusion(self, sample_directory_structure):
         """Test that virtual environment directories are properly excluded"""
         base_path = sample_directory_structure
-        
+
         # Define exclusion patterns (matching ContextKeeper's logic)
         exclusion_patterns = [
-            'venv', '.venv', 'env', '.env',
-            'site-packages', '__pycache__',
-            'node_modules', '.git', '.pytest_cache',
-            'build', 'dist', '.tox'
+            "venv",
+            ".venv",
+            "env",
+            ".env",
+            "site-packages",
+            "__pycache__",
+            "node_modules",
+            ".git",
+            ".pytest_cache",
+            "build",
+            "dist",
+            ".tox",
         ]
-        
+
         def should_exclude_path(path):
             """Check if a path should be excluded based on exclusion patterns"""
             path_str = str(path)
             path_parts = Path(path).parts
-            
+
             for pattern in exclusion_patterns:
                 if pattern in path_parts:
                     return True
                 if pattern in path_str:
                     return True
-            
+
             return False
-        
+
         # Test specific exclusions
         excluded_paths = [
             base_path / "venv/lib/python3.9/site-packages/requests/__init__.py",
@@ -120,28 +129,36 @@ class TestPathFilteringLogic:
             base_path / ".git/objects/12/34567890abcdef",
             base_path / "__pycache__/test/app.cpython-39.pyc",
             base_path / "build/lib/mypackage/__init__.py",
-            base_path / "dist/mypackage-1.0.0/setup.py"
+            base_path / "dist/mypackage-1.0.0/setup.py",
         ]
-        
+
         for path in excluded_paths:
             assert should_exclude_path(path), f"Path should be excluded: {path}"
-    
+
     def test_project_file_inclusion(self, sample_directory_structure):
         """Test that legitimate project files are properly included"""
         base_path = sample_directory_structure
-        
+
         def should_exclude_path(path):
             """Simplified exclusion logic for testing"""
             exclusion_patterns = [
-                'venv', '.venv', 'env', '.env',
-                'site-packages', '__pycache__',
-                'node_modules', '.git', '.pytest_cache',
-                'build', 'dist', '.tox'
+                "venv",
+                ".venv",
+                "env",
+                ".env",
+                "site-packages",
+                "__pycache__",
+                "node_modules",
+                ".git",
+                ".pytest_cache",
+                "build",
+                "dist",
+                ".tox",
             ]
-            
+
             path_parts = Path(path).parts
             return any(pattern in path_parts for pattern in exclusion_patterns)
-        
+
         # Test specific inclusions
         included_paths = [
             base_path / "src/main/app.py",
@@ -150,23 +167,23 @@ class TestPathFilteringLogic:
             base_path / "tests/integration/test_api.py",
             base_path / "README.md",
             base_path / "setup.py",
-            base_path / "requirements.txt"
+            base_path / "requirements.txt",
         ]
-        
+
         for path in included_paths:
             assert not should_exclude_path(path), f"Path should be included: {path}"
-    
+
     def test_nested_exclusion_logic(self, sample_directory_structure):
         """Test exclusion logic for deeply nested structures"""
         base_path = sample_directory_structure
-        
+
         # Test deeply nested venv paths
         deep_venv_paths = [
             "venv/lib/python3.9/site-packages/requests/adapters.py",
             "venv/lib/python3.9/site-packages/urllib3/connectionpool.py",
-            ".venv/lib/python3.9/site-packages/numpy/core/multiarray.py"
+            ".venv/lib/python3.9/site-packages/numpy/core/multiarray.py",
         ]
-        
+
         def is_in_excluded_directory(path, exclusions):
             """Check if path is within any excluded directory"""
             path_obj = Path(path)
@@ -174,65 +191,94 @@ class TestPathFilteringLogic:
                 if part in exclusions:
                     return True
             return False
-        
-        exclusions = {'venv', '.venv', 'site-packages'}
-        
+
+        exclusions = {"venv", ".venv", "site-packages"}
+
         for path_str in deep_venv_paths:
             full_path = base_path / path_str
-            assert is_in_excluded_directory(full_path, exclusions), \
-                f"Deeply nested path should be excluded: {path_str}"
-    
+            assert is_in_excluded_directory(
+                full_path, exclusions
+            ), f"Deeply nested path should be excluded: {path_str}"
+
     def test_file_extension_filtering(self, sample_directory_structure):
         """Test filtering based on file extensions"""
         base_path = sample_directory_structure
-        
+
         # Create additional test files with various extensions
         test_files = [
-            "src/code.py",      # Should include
-            "src/data.json",    # Should include
+            "src/code.py",  # Should include
+            "src/data.json",  # Should include
             "src/config.yaml",  # Should include
-            "src/readme.md",    # Should include
-            "src/styles.css",   # Should include
-            "src/app.js",       # Should include
-            "src/temp.tmp",     # Might exclude
-            "src/backup.bak",   # Might exclude
-            "src/compiled.pyc", # Should exclude
-            "src/object.o",     # Should exclude
+            "src/readme.md",  # Should include
+            "src/styles.css",  # Should include
+            "src/app.js",  # Should include
+            "src/temp.tmp",  # Might exclude
+            "src/backup.bak",  # Might exclude
+            "src/compiled.pyc",  # Should exclude
+            "src/object.o",  # Should exclude
         ]
-        
+
         # Define inclusion patterns for code files
-        code_extensions = {'.py', '.js', '.ts', '.java', '.cpp', '.c', '.h', 
-                          '.md', '.rst', '.txt', '.json', '.yaml', '.yml', 
-                          '.xml', '.html', '.css', '.scss', '.sql'}
-        
+        code_extensions = {
+            ".py",
+            ".js",
+            ".ts",
+            ".java",
+            ".cpp",
+            ".c",
+            ".h",
+            ".md",
+            ".rst",
+            ".txt",
+            ".json",
+            ".yaml",
+            ".yml",
+            ".xml",
+            ".html",
+            ".css",
+            ".scss",
+            ".sql",
+        }
+
         # Define exclusion patterns for generated files
-        exclude_extensions = {'.pyc', '.pyo', '.o', '.so', '.exe', '.dll',
-                             '.tmp', '.temp', '.bak', '.backup', '.log'}
-        
+        exclude_extensions = {
+            ".pyc",
+            ".pyo",
+            ".o",
+            ".so",
+            ".exe",
+            ".dll",
+            ".tmp",
+            ".temp",
+            ".bak",
+            ".backup",
+            ".log",
+        }
+
         def should_include_file(file_path):
             """Determine if file should be included based on extension"""
             suffix = Path(file_path).suffix.lower()
-            
+
             # Exclude specific extensions
             if suffix in exclude_extensions:
                 return False
-            
+
             # Include code extensions
             if suffix in code_extensions:
                 return True
-            
+
             # Default to include if no specific rule
             return True
-        
+
         # Test the logic
         for file_path in test_files:
             full_path = base_path / file_path
             full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_text("test content")
-            
+
             include = should_include_file(full_path)
             suffix = Path(file_path).suffix.lower()
-            
+
             if suffix in exclude_extensions:
                 assert not include, f"File with extension {suffix} should be excluded"
             elif suffix in code_extensions:
@@ -242,99 +288,105 @@ class TestPathFilteringLogic:
 @pytest.mark.unit
 class TestDirectoryTraversal:
     """Test directory traversal logic and performance"""
-    
+
     def test_recursive_directory_traversal(self, temp_dir):
         """Test recursive traversal with proper filtering"""
         base_path = Path(temp_dir)
-        
+
         # Create nested structure
         test_structure = [
             "project/src/main.py",
             "project/src/utils/helper.py",
             "project/tests/test_main.py",
             "project/venv/lib/python3.9/site-packages/package.py",
-            "project/docs/readme.md"
+            "project/docs/readme.md",
         ]
-        
+
         for file_path in test_structure:
             full_path = base_path / file_path
             full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_text("test content")
-        
+
         def traverse_directory(root_path, exclude_patterns):
             """Simulate directory traversal with filtering"""
             included_files = []
-            
+
             for root, dirs, files in os.walk(root_path):
                 # Filter directories to avoid traversing excluded ones
                 dirs[:] = [d for d in dirs if d not in exclude_patterns]
-                
+
                 for file in files:
                     file_path = Path(root) / file
-                    
+
                     # Check if file is in excluded path
                     should_exclude = False
                     for part in file_path.parts:
                         if part in exclude_patterns:
                             should_exclude = True
                             break
-                    
+
                     if not should_exclude:
                         included_files.append(file_path)
-            
+
             return included_files
-        
-        exclude_patterns = {'venv', '.venv', '__pycache__', '.git'}
+
+        exclude_patterns = {"venv", ".venv", "__pycache__", ".git"}
         included_files = traverse_directory(base_path, exclude_patterns)
-        
+
         # Verify results
-        assert len(included_files) >= 4  # Should include main.py, helper.py, test_main.py, readme.md
-        
+        assert (
+            len(included_files) >= 4
+        )  # Should include main.py, helper.py, test_main.py, readme.md
+
         # Verify venv files are excluded
-        venv_files = [f for f in included_files if 'venv' in str(f)]
+        venv_files = [f for f in included_files if "venv" in str(f)]
         assert len(venv_files) == 0, "Virtual environment files should be excluded"
-    
+
     def test_symlink_handling(self, temp_dir):
         """Test handling of symbolic links in directory traversal"""
         base_path = Path(temp_dir)
-        
+
         # Create real file and directory
         real_file = base_path / "real_file.py"
         real_dir = base_path / "real_dir"
         real_dir.mkdir()
         (real_dir / "content.py").write_text("real content")
         real_file.write_text("real file content")
-        
+
         # Create symbolic links if supported by the system
         try:
             symlink_file = base_path / "symlink_file.py"
             symlink_dir = base_path / "symlink_dir"
-            
+
             symlink_file.symlink_to(real_file)
             symlink_dir.symlink_to(real_dir)
-            
+
             # Test symlink detection
             assert symlink_file.is_symlink()
             assert symlink_dir.is_symlink()
             assert not real_file.is_symlink()
             assert not real_dir.is_symlink()
-            
+
         except (OSError, NotImplementedError):
             # Symlinks not supported on this system
             pytest.skip("Symbolic links not supported on this system")
-    
+
     def test_permission_error_handling(self, temp_dir):
         """Test handling of permission errors during traversal"""
         base_path = Path(temp_dir)
-        
+
         # Create a file and then make it unreadable (if possible)
         test_file = base_path / "permission_test.py"
         test_file.write_text("test content")
-        
+
         try:
+            # Skip test if running as root, since permission changes may be ignored
+            if os.name != "nt" and hasattr(os, "geteuid") and os.geteuid() == 0:
+                pytest.skip("Permission checks are ineffective when run as root")
+
             # Remove read permissions (Unix-like systems)
             os.chmod(test_file, 0o000)
-            
+
             def safe_read_file(file_path):
                 """Safely attempt to read a file"""
                 try:
@@ -343,15 +395,15 @@ class TestDirectoryTraversal:
                     return None
                 except OSError:
                     return None
-            
+
             # Test that permission errors are handled gracefully
             content = safe_read_file(test_file)
             assert content is None, "Should handle permission error gracefully"
-            
+
         except (OSError, NotImplementedError):
             # Permission modification not supported
             pytest.skip("Permission modification not supported on this system")
-        
+
         finally:
             # Restore permissions for cleanup
             try:
@@ -360,10 +412,10 @@ class TestDirectoryTraversal:
                 pass
 
 
-@pytest.mark.unit  
+@pytest.mark.unit
 class TestPathNormalization:
     """Test path normalization and cross-platform compatibility"""
-    
+
     def test_path_separator_normalization(self):
         """Test normalization of path separators across platforms"""
         test_paths = [
@@ -371,39 +423,35 @@ class TestPathNormalization:
             "src\\main\\app.py",  # Windows-style
             "src/main\\utils/helper.py",  # Mixed style
             "./src/main/app.py",  # Relative with dot
-            "../src/main/app.py"  # Relative with parent
+            "../src/main/app.py",  # Relative with parent
         ]
-        
-        def normalize_path(path_str):
-            """Normalize path separators and resolve relative parts"""
-            return Path(path_str).as_posix()
-        
+
         for path_str in test_paths:
             normalized = normalize_path(path_str)
-            
+
             # Should use forward slashes
-            assert '\\' not in normalized or os.name == 'nt'
-            
+            assert "\\" not in normalized or os.name == "nt"
+
             # Should be a valid path
             assert isinstance(normalized, str)
             assert len(normalized) > 0
-    
+
     def test_absolute_vs_relative_paths(self, temp_dir):
         """Test handling of absolute vs relative paths"""
         base_path = Path(temp_dir)
-        
+
         # Create test file
         test_file = base_path / "test.py"
         test_file.write_text("test content")
-        
+
         # Test absolute path
         absolute_path = test_file.absolute()
         assert absolute_path.is_absolute()
-        
+
         # Test relative path
         relative_path = Path("test.py")
         assert not relative_path.is_absolute()
-        
+
         # Test conversion
         def ensure_absolute(path, base_dir):
             """Ensure path is absolute"""
@@ -412,28 +460,28 @@ class TestPathNormalization:
                 return path_obj
             else:
                 return (Path(base_dir) / path_obj).absolute()
-        
+
         abs_from_rel = ensure_absolute("test.py", temp_dir)
         assert abs_from_rel.is_absolute()
         assert abs_from_rel.name == "test.py"
-    
+
     def test_case_sensitivity_handling(self):
         """Test handling of case sensitivity in file paths"""
         test_cases = [
             ("README.md", "readme.md"),
             ("SRC/main.py", "src/main.py"),
-            ("Tests/Unit/test.py", "tests/unit/test.py")
+            ("Tests/Unit/test.py", "tests/unit/test.py"),
         ]
-        
+
         def normalize_case(path_str):
             """Normalize case for case-insensitive comparison"""
             return str(Path(path_str)).lower()
-        
+
         for original, expected_lower in test_cases:
             normalized = normalize_case(original)
-            
-            if os.name == 'nt':  # Windows is case-insensitive
-                assert normalized == expected_lower.replace('/', '\\').lower()
+
+            if os.name == "nt":  # Windows is case-insensitive
+                assert normalized == expected_lower.replace("/", "\\").lower()
             else:  # Unix-like systems preserve case
                 # Still normalize for comparison
                 assert isinstance(normalized, str)
@@ -442,59 +490,63 @@ class TestPathNormalization:
 @pytest.mark.unit
 class TestFilteringPerformance:
     """Test performance characteristics of path filtering"""
-    
+
     def test_large_directory_filtering_performance(self, temp_dir):
         """Test filtering performance with large number of files"""
         import time
-        
+
         base_path = Path(temp_dir)
-        
+
         # Create many files for performance testing
         num_files = 100  # Reduced for test speed
-        file_types = ['.py', '.js', '.md', '.json', '.txt']
-        
+        file_types = [".py", ".js", ".md", ".json", ".txt"]
+
         start_time = time.time()
-        
+
         for i in range(num_files):
             file_ext = file_types[i % len(file_types)]
             file_path = base_path / f"file_{i:04d}{file_ext}"
             file_path.write_text(f"Content of file {i}")
-        
+
         creation_time = time.time() - start_time
-        
+
         # Test filtering performance
-        exclude_patterns = {'venv', '.venv', '__pycache__', '.git'}
-        
+        exclude_patterns = {"venv", ".venv", "__pycache__", ".git"}
+
         start_filter_time = time.time()
-        
+
         filtered_files = []
-        for file_path in base_path.rglob('*'):
+        for file_path in base_path.rglob("*"):
             if file_path.is_file():
-                should_exclude = any(pattern in file_path.parts for pattern in exclude_patterns)
+                should_exclude = any(
+                    pattern in file_path.parts for pattern in exclude_patterns
+                )
                 if not should_exclude:
                     filtered_files.append(file_path)
-        
+
         filter_time = time.time() - start_filter_time
-        
+
         # Performance assertions
         assert creation_time < 5.0, "File creation should be fast"
         assert filter_time < 2.0, "Filtering should be fast"
-        assert len(filtered_files) == num_files, "All files should be included (no exclusions)"
-    
+        assert (
+            len(filtered_files) == num_files
+        ), "All files should be included (no exclusions)"
+
     def test_exclusion_pattern_efficiency(self):
         """Test efficiency of different exclusion pattern matching methods"""
         import time
-        
+
         test_paths = [
             "src/main/app.py",
             "venv/lib/python3.9/site-packages/requests/__init__.py",
             "tests/unit/test_app.py",
             "node_modules/react/lib/react.js",
-            "docs/source/index.rst"
+            "docs/source/index.rst",
         ] * 20  # Repeat for performance testing
-        
-        exclude_patterns = {'venv', '.venv', '__pycache__', '.git', 'node_modules'}
-        
+
+        exclude_patterns = {"venv", ".venv", "__pycache__", ".git", "node_modules"}
+
         # Method 1: String-based checking
         def method1_string_check(paths, patterns):
             results = []
@@ -502,7 +554,7 @@ class TestFilteringPerformance:
                 should_exclude = any(pattern in path for pattern in patterns)
                 results.append(not should_exclude)
             return results
-        
+
         # Method 2: Path parts checking
         def method2_parts_check(paths, patterns):
             results = []
@@ -511,23 +563,25 @@ class TestFilteringPerformance:
                 should_exclude = any(pattern in path_parts for pattern in patterns)
                 results.append(not should_exclude)
             return results
-        
+
         # Test both methods
         start_time = time.time()
         results1 = method1_string_check(test_paths, exclude_patterns)
         time1 = time.time() - start_time
-        
+
         start_time = time.time()
         results2 = method2_parts_check(test_paths, exclude_patterns)
         time2 = time.time() - start_time
-        
+
         # Both methods should be fast
         assert time1 < 1.0, "String-based method should be fast"
         assert time2 < 1.0, "Parts-based method should be fast"
-        
+
         # Results should be consistent for most cases
         # (Some edge cases might differ, but major exclusions should match)
-        major_exclusions = sum(1 for r1, r2 in zip(results1, results2) if not r1 and not r2)
+        major_exclusions = sum(
+            1 for r1, r2 in zip(results1, results2) if not r1 and not r2
+        )
         assert major_exclusions > 0, "Both methods should exclude some paths"
 
 


### PR DESCRIPTION
## Summary
- add `normalize_path` utility for forward-slash path normalization
- use utility in path filtering tests and skip permission check when running as root

## Testing
- `pre-commit run --files src/core/path_utils.py tests/unit/test_path_filtering.py`
- `pytest tests/unit/test_path_filtering.py::TestDirectoryTraversal::test_permission_error_handling tests/unit/test_path_filtering.py::TestPathNormalization::test_path_separator_normalization`
- `pytest` *(fails: 16 failed, 62 passed, 2 skipped, 15 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e7b37664832e8995b1d186bf6469